### PR TITLE
Fix sign check by verifying timestamp

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -261,7 +261,7 @@ async def access_log_middleware(request: fastapi.Request, call_next):
 
 def get_cluster_from_sign(hash: str, s: str, e: str) -> Optional[str]:
     for cluster in clusters.clusters:
-        if check_sign_without_time(hash, cluster._token._secret, s, e):
+        if check_sign(hash, cluster._token._secret, s, e):
             return cluster.id
     return None
 


### PR DESCRIPTION
## Summary
- validate cluster signatures using `check_sign`
- reject signatures older than 5 minutes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880ab1b8430832b90e5351ceeeecd77